### PR TITLE
Python3 install

### DIFF
--- a/install_python3.sh
+++ b/install_python3.sh
@@ -1,0 +1,9 @@
+sudo yum install -y https://centos7.iuscommunity.org/ius-release.rpm
+sudo yum install -y python36u python36u-libs python36u-devel python36u-pip
+
+# pythonライブラリインストール
+sudo pip3 install --upgrade pip
+sudo pip3 install --upgrade setuptools
+sudo pip3 install requests
+# google cloud
+sudo pip3 install --upgrade google-cloud-bigquery

--- a/install_python3.sh
+++ b/install_python3.sh
@@ -1,4 +1,4 @@
-sudo yum install -y https://centos7.iuscommunity.org/ius-release.rpm
+sudo yum install -y https://repo.ius.io/ius-release-el7.rpm
 sudo yum install -y python36u python36u-libs python36u-devel python36u-pip
 
 # pythonライブラリインストール


### PR DESCRIPTION
issue: [#3 ]

Python3.6のインストールをまとめたスクリプト。
ius-release.npmのURLが変更されているので注意が必要。

[Deprecation of legacy ius-release.rpm redirect links #18](https://github.com/iusrepo/announce/issues/18)